### PR TITLE
Feat/us05 11 cadastro login resp

### DIFF
--- a/src/app/controllers/AdmController.js
+++ b/src/app/controllers/AdmController.js
@@ -5,7 +5,8 @@ import User from '../models/User';
 import UserController from './UserController';
 import dbConfig from '../../config/database';
 
-const sequelize = new Sequelize(dbConfig.database, dbConfig.username, dbConfig.password, { host: dbConfig.host, dialect: dbConfig.dialect });
+const sequelize = new Sequelize(dbConfig.database, dbConfig.username,
+  dbConfig.password, { host: dbConfig.host, dialect: dbConfig.dialect });
 
 class AdmController extends UserController {
   async register(req, res) {
@@ -29,7 +30,6 @@ class AdmController extends UserController {
       });
     } catch (err) {
       t.rollback();
-      console.log(err.error);
       return res.status(500).json({ error: err.stack });
     }
   }

--- a/src/app/controllers/AdmController.js
+++ b/src/app/controllers/AdmController.js
@@ -1,9 +1,7 @@
 import Child from '../models/Child';
 import UserController from './UserController';
 
-
 class AdmController extends UserController {
-  
   async register(req, res) {
     try {
       const usertype = 2;

--- a/src/app/controllers/AdmController.js
+++ b/src/app/controllers/AdmController.js
@@ -3,7 +3,28 @@ import User from '../models/User';
 import UserController from './UserController';
 
 class AdmController extends UserController {
-
+  async register(req, res) {
+    try {
+      const usertype = 2;
+      const {
+        name, cpf, birthday, email, password, registration,
+      } = req.body;
+      const { id } = await User.create({
+        usertype, name, cpf, birthday, email, password,
+      });
+      await Professionals.create({ id, professionalType: 'adm', registration });
+      return res.json({
+        usertype,
+        name,
+        cpf,
+        birthday,
+        email,
+      });
+    } catch (err) {
+      console.log(err);
+      return res.status(500).json({ error: err.stack });
+    }
+  }
 }
 
 export default new AdmController();

--- a/src/app/controllers/AuthController.js
+++ b/src/app/controllers/AuthController.js
@@ -4,7 +4,6 @@ import User from '../models/User';
 import authConfig from '../../config/auth.config';
 
 class AuthController {
-  
   async authenticate(req, res) {
 
   }

--- a/src/app/controllers/AuthController.js
+++ b/src/app/controllers/AuthController.js
@@ -16,7 +16,7 @@ class AuthController {
 
   }
 
-  async login(req, rest) {
+  async login(req, res) {
     try {
       const { email, password } = req.body;
 
@@ -40,7 +40,7 @@ class AuthController {
           usertype,
         },
 
-        token: jwt.sign({ id }, authConfig.secret, {
+        token: jwt.sign({ id, usertype }, authConfig.secret, {
           expiresIn: authConfig.expiresIn,
         }),
 

--- a/src/app/controllers/EcController.js
+++ b/src/app/controllers/EcController.js
@@ -1,25 +1,22 @@
-import EC from "../models/EC";
+import EC from '../models/Ec';
 
-class EC {
+class EcController {
+  async store(req, res) {
+    try {
+      const {
+        id, name, adress, description,
+      } = await EC.create(req.body);
 
-    async store(req, res) {
-
-        try {
-
-          const { id,name,adress,description} = await EC.create(req.body);
-    
-          return res.json({
-            id,
-            name,
-            adress, 
-            description
-          });
-    
-        }catch(err){
-          return res.status(500).json({ error: 'Falha na criação do centro educacional.'});
-        }
-      }
-
+      return res.json({
+        id,
+        name,
+        adress,
+        description,
+      });
+    } catch (err) {
+      return res.status(500).json({ error: 'Falha na criação do centro educacional.' });
+    }
+  }
 }
 
-export default new EC();
+export default new EcController();

--- a/src/app/controllers/GuardianController.js
+++ b/src/app/controllers/GuardianController.js
@@ -4,7 +4,8 @@ import User from '../models/User';
 import Guardian from '../models/Guardian';
 import dbConfig from '../../config/database';
 
-const sequelize = new Sequelize(dbConfig.database, dbConfig.username, dbConfig.password, { host: dbConfig.host, dialect: dbConfig.dialect });
+const sequelize = new Sequelize(dbConfig.database, dbConfig.username,
+  dbConfig.password, { host: dbConfig.host, dialect: dbConfig.dialect });
 
 class GuardianController extends UserController {
   async list(req, res) {
@@ -38,7 +39,6 @@ class GuardianController extends UserController {
       });
     } catch (err) {
       t.rollback();
-      console.log(err);
       return res.status(500).json({ error: err.stack });
     }
   }

--- a/src/app/controllers/GuardianController.js
+++ b/src/app/controllers/GuardianController.js
@@ -1,0 +1,40 @@
+import UserController from './UserController';
+import User from '../models/User';
+import Guardian from '../models/Guardian';
+
+class GuardianController extends UserController {
+  async list(req, res) {
+    try {
+      const users = await User.findAll();
+      const glist = await Guardian.findAll();
+      return res.json({ users, guardians: glist });
+    } catch (err) {
+      return res.status(500).json({ error: err.stack });
+    }
+  }
+
+  async register(req, res) {
+    try {
+      const usertype = 0;
+      const {
+        name, cpf, birthday, email, password, adress,
+      } = req.body;
+      const { id } = await User.create({
+        usertype, name, cpf, birthday, email, password,
+      });
+      await Guardian.create({ id, adress });
+      return res.json({
+        usertype,
+        name,
+        cpf,
+        birthday,
+        email,
+      });
+    } catch (err) {
+      console.log(err);
+      return res.status(500).json({ error: err.stack });
+    }
+  }
+}
+
+export default new GuardianController();

--- a/src/app/controllers/TeacherController.js
+++ b/src/app/controllers/TeacherController.js
@@ -15,8 +15,9 @@ class TeacherController extends UserController {
 
   async register(req, res) {
     try {
+      const usertype = 1;
       const {
-        usertype, name, cpf, birthday, email, password, registration,
+        name, cpf, birthday, email, password, registration,
       } = req.body;
       const { id } = await User.create({
         usertype, name, cpf, birthday, email, password,

--- a/src/app/controllers/TeacherController.js
+++ b/src/app/controllers/TeacherController.js
@@ -4,7 +4,8 @@ import Professionals from '../models/Professionals';
 import User from '../models/User';
 import dbConfig from '../../config/database';
 
-const sequelize = new Sequelize(dbConfig.database, dbConfig.username, dbConfig.password, { host: dbConfig.host, dialect: dbConfig.dialect });
+const sequelize = new Sequelize(dbConfig.database, dbConfig.username,
+  dbConfig.password, { host: dbConfig.host, dialect: dbConfig.dialect });
 
 class TeacherController extends UserController {
   async list(req, res) {
@@ -38,7 +39,6 @@ class TeacherController extends UserController {
       });
     } catch (err) {
       t.rollback();
-      console.log(err.error);
       return res.status(500).json({ error: err.stack });
     }
   }

--- a/src/app/controllers/TeacherController.js
+++ b/src/app/controllers/TeacherController.js
@@ -29,7 +29,6 @@ class TeacherController extends UserController {
         cpf,
         birthday,
         email,
-        password,
       });
     } catch (err) {
       console.log(err);

--- a/src/app/controllers/UserController.js
+++ b/src/app/controllers/UserController.js
@@ -1,7 +1,5 @@
-import User from '../models/User';
-
 class UserController {
-  async register(req, res) { }
+  register() { }
 }
 
 export default UserController;

--- a/src/app/middlewares/middleware.js
+++ b/src/app/middlewares/middleware.js
@@ -13,7 +13,7 @@ class Middleware {
 
       const decoded = await promisify(jwt.verify)(token, authConfig.secret);
 
-      if (decoded.usertype != 2) {
+      if (decoded.usertype !== 2) {
         return res.status(401).json({ error: 'Acesso negado.' });
       }
       req.adminId = decoded.id;
@@ -34,7 +34,7 @@ class Middleware {
 
       const decoded = await promisify(jwt.verify)(token, authConfig.secret);
 
-      if (decoded.usertype != 1) {
+      if (decoded.usertype !== 1) {
         return res.status(401).json({ error: 'Acesso negado.' });
       }
       req.adminId = decoded.id;
@@ -55,7 +55,7 @@ class Middleware {
 
       const decoded = await promisify(jwt.verify)(token, authConfig.secret);
 
-      if (decoded.usertype != 0) {
+      if (decoded.usertype !== 0) {
         return res.status(401).json({ error: 'Acesso negado.' });
       }
       req.adminId = decoded.id;

--- a/src/app/middlewares/middleware.js
+++ b/src/app/middlewares/middleware.js
@@ -6,65 +6,65 @@ class Middleware {
   async verifyAdm(req, res, next) {
     try {
       const token = req.headers.authorization;
-  
+
       if (!token) {
         return res.status(401).json({ error: 'Token não existe.' });
       }
-  
+
       const decoded = await promisify(jwt.verify)(token, authConfig.secret);
 
-      if (decoded.usertype != 2){
+      if (decoded.usertype != 2) {
         return res.status(401).json({ error: 'Acesso negado.' });
       }
       req.adminId = decoded.id;
-  
+
       return next();
     } catch (err) {
       return res.status(401).json({ error: err.stack });
     }
-  };
+  }
 
   async verifyTeacher(req, res, next) {
     try {
       const token = req.headers.authorization;
-  
+
       if (!token) {
         return res.status(401).json({ error: 'Token não existe.' });
       }
-  
+
       const decoded = await promisify(jwt.verify)(token, authConfig.secret);
 
-      if (decoded.usertype != 1){
+      if (decoded.usertype != 1) {
         return res.status(401).json({ error: 'Acesso negado.' });
       }
       req.adminId = decoded.id;
-  
+
       return next();
     } catch (err) {
       return res.status(401).json({ error: err.stack });
     }
-  };
+  }
 
   async verifyGuardian(req, res, next) {
     try {
       const token = req.headers.authorization;
-  
+
       if (!token) {
         return res.status(401).json({ error: 'Token não existe.' });
       }
-  
+
       const decoded = await promisify(jwt.verify)(token, authConfig.secret);
 
-      if (decoded.usertype != 0){
+      if (decoded.usertype != 0) {
         return res.status(401).json({ error: 'Acesso negado.' });
       }
       req.adminId = decoded.id;
-  
+
       return next();
     } catch (err) {
       return res.status(401).json({ error: err.stack });
     }
-  };
+  }
 }
 
 export default new Middleware();

--- a/src/app/middlewares/middleware.js
+++ b/src/app/middlewares/middleware.js
@@ -2,20 +2,69 @@ import jwt from 'jsonwebtoken';
 import { promisify } from 'util';
 import authConfig from '../../config/auth.config';
 
-export default async (req, res, next) => {
-  try {
-    const token = req.headers.authorization;
+class Middleware {
+  async verifyAdm(req, res, next) {
+    try {
+      const token = req.headers.authorization;
+  
+      if (!token) {
+        return res.status(401).json({ error: 'Token não existe.' });
+      }
+  
+      const decoded = await promisify(jwt.verify)(token, authConfig.secret);
 
-    if (!token) {
-      return res.status(401).json({ error: 'Token não existe.' });
+      if (decoded.usertype != 2){
+        return res.status(401).json({ error: 'Acesso negado.' });
+      }
+      req.adminId = decoded.id;
+  
+      return next();
+    } catch (err) {
+      return res.status(401).json({ error: err.stack });
     }
+  };
 
-    const decoded = await promisify(jwt.verify)(token, authConfig.secret);
+  async verifyTeacher(req, res, next) {
+    try {
+      const token = req.headers.authorization;
+  
+      if (!token) {
+        return res.status(401).json({ error: 'Token não existe.' });
+      }
+  
+      const decoded = await promisify(jwt.verify)(token, authConfig.secret);
 
-    req.adminId = decoded.id;
+      if (decoded.usertype != 1){
+        return res.status(401).json({ error: 'Acesso negado.' });
+      }
+      req.adminId = decoded.id;
+  
+      return next();
+    } catch (err) {
+      return res.status(401).json({ error: err.stack });
+    }
+  };
 
-    return next();
-  } catch (err) {
-    return res.status(401).json({ error: err.stack });
-  }
-};
+  async verifyGuardian(req, res, next) {
+    try {
+      const token = req.headers.authorization;
+  
+      if (!token) {
+        return res.status(401).json({ error: 'Token não existe.' });
+      }
+  
+      const decoded = await promisify(jwt.verify)(token, authConfig.secret);
+
+      if (decoded.usertype != 0){
+        return res.status(401).json({ error: 'Acesso negado.' });
+      }
+      req.adminId = decoded.id;
+  
+      return next();
+    } catch (err) {
+      return res.status(401).json({ error: err.stack });
+    }
+  };
+}
+
+export default new Middleware();

--- a/src/app/models/Ec.js
+++ b/src/app/models/Ec.js
@@ -15,7 +15,7 @@ class Ec extends Model {
     this.hasMany(models.Class);
     this.hasMany(models.Adm);
     this.hasMany(models.Teacher);
-  }*/
+  } */
 }
 
 export default Ec;

--- a/src/app/models/Guardian.js
+++ b/src/app/models/Guardian.js
@@ -1,26 +1,21 @@
-/* import { Sequelize } from "sequelize";
-import User from './User.js';
-import Child from './Child.js';
-const Model = Sequelize.Model;
-class Guardian extends Model { }
-Guardian.init({
-  // attributes
-  idguardian: {
-    allowNull: false,
-    primaryKey: true,
-    type: Sequelize.UUIDV4
-  },
-  adress: {
-    type: Sequelize.STRING(256),
-    allowNull: false
-  },
-}, {
-  sequelize,
-  modelName: 'guardian'
-  // options
-});
+import Sequelize, { Model } from 'sequelize';
 
-Guardian.hasOne(User);
-Guardian.hasMany(Child);
+class Guardian extends Model {
+  static init(sequelize) {
+    super.init(
+      {
+        adress: Sequelize.STRING(256),
+      },
+      {
+        sequelize,
+        // options
+      },
+    );
+    return this;
+  }
+}
 
-export default Guardian; */
+// Guardian.hasOne(User);
+// Guardian.hasMany(Child);
+
+export default Guardian;

--- a/src/app/models/Professionals.js
+++ b/src/app/models/Professionals.js
@@ -1,5 +1,4 @@
 import Sequelize, { Model } from 'sequelize';
-import User from './User.js';
 
 class Professionals extends Model {
   static init(sequelize) {

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -17,7 +17,7 @@ class Database {
   init() {
     this.connection = new Sequelize(dbConfig);
 
-       models.map((model) => model.init(this.connection));
+    models.map((model) => model.init(this.connection));
     /* models.map((model) => model.associate(this.connection.model)); */
   }
 }

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -3,8 +3,9 @@ import User from '../app/models/User';
 import dbConfig from '../config/database';
 import Ec from '../app/models/Ec.js';
 import Professionals from '../app/models/Professionals';
+import Guardian from '../app/models/Guardian';
 
-const models = [User, Professionals];
+const models = [User, Professionals, Guardian];
 
 class Database {
   constructor() {

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,14 +1,23 @@
 import { Router } from 'express';
 import AuthController from './app/controllers/AuthController.js';
-import AuthMiddleware from './app/middlewares/middleware.js';
+import Middleware from './app/middlewares/middleware.js';
 import AdmController from './app/controllers/AdmController.js';
 import TeacherController from './app/controllers/TeacherController.js';
+import GuardianController from './app/controllers/GuardianController.js';
 
 const routes = new Router();
-
+// Unverified routes
 routes.post('/login', AuthController.login);
+routes.post('/dev/register-adm', AdmController.register);
+routes.post('/register-guardian', GuardianController.register);
+// Admin routes
+routes.use(Middleware.verifyAdm);
 routes.post('/adm/register-teacher', TeacherController.register);
 routes.get('/list-professionals', TeacherController.list);
-routes.use(AuthMiddleware);
+routes.get('/list-guardians', GuardianController.list);
+// Teacher routes
+routes.use(Middleware.verifyTeacher);
+// Guardian routes
+routes.use(Middleware.verifyGuardian);
 
 export default routes;

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,13 +1,10 @@
 import { Router } from 'express';
-import AuthController from './app/controllers/AuthController.js';
-import Middleware from './app/middlewares/middleware.js';
-import AdmController from './app/controllers/AdmController.js';
-import TeacherController from './app/controllers/TeacherController.js';
-import GuardianController from './app/controllers/GuardianController.js';
-import ChildController from './app/controllers/ChildController';
 import AuthController from './app/controllers/AuthController';
+import Middleware from './app/middlewares/middleware';
+import AdmController from './app/controllers/AdmController';
 import TeacherController from './app/controllers/TeacherController';
-
+import GuardianController from './app/controllers/GuardianController';
+import ChildController from './app/controllers/ChildController';
 
 const routes = new Router();
 // Unverified routes

--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,4 @@
-import express from 'express';
+// import express from 'express';
 import app from './app';
 
 require('./database');


### PR DESCRIPTION
Cadastro e login de responsável
Autenticação separadas para responsável, professor e admin
Utilizando transactions nos register de user agora.
Algumas refatorações.

Rota para cadastro de responsável `localhost:3333/register-guardian`

body exemplo: 

```json
{
    "name": "Mateus", 
    "cpf": "56da5sss165", 
    "birthday": 31122021,
    "email": "o.mateus.p@gmail.com", 
    "password": "eoqmaluco",
    "adress": "rua qualquer"
}
```

Rota para login `localhost:3333/login`

body exemplo:

```json
{
    "email": "o.mateus.p@gmail.com", 
    "password": "eoqmaluco"
}
```

Close #11 