### PR TITLE
Feat/us07 14 listar atividades crianca

### DIFF
--- a/src/app/controllers/ActivityController.js
+++ b/src/app/controllers/ActivityController.js
@@ -1,8 +1,7 @@
 import ProjectInterface from '../others/ProjectInterface';
 
 class ActivityController extends ProjectInterface {
-  
-  constructor(){
+  constructor() {
     super();
     this._ProjectType = 'activity';
   }

--- a/src/app/controllers/AdmController.js
+++ b/src/app/controllers/AdmController.js
@@ -122,13 +122,13 @@ class AdmController extends UserController {
       const guardian_child = await GuardianChild.findOne({
         where: {
           fk_id_child: id,
-          guardian_cpf: cpf
-        }
+          guardian_cpf: cpf,
+        },
       });
       if (guardian_child === null) {
         return res.status(404).json({ message: 'Responsável não encontrado para essa criança.' });
       }
-      
+
       await guardian_child.destroy();
 
       return res.status(200).json({ message: 'Responsável deletado!' });
@@ -144,10 +144,10 @@ class AdmController extends UserController {
       // TODO: adicionar id EC na hora de criar a classe
       const class_ver = await Class.findOne({
         where: {
-          code: code
-        }
-      })
-      if(class_ver !== null){
+          code,
+        },
+      });
+      if (class_ver !== null) {
         return res.status(409).json({ message: 'Já existe uma turma com esse código.', class: class_ver });
       }
 
@@ -175,11 +175,10 @@ class AdmController extends UserController {
 
       const child = await Child.findByPk(child_id);
       child.update({
-        fk_idClass: class_id
-      }) 
+        fk_idClass: class_id,
+      });
 
-      return res.status(200).json({ msg: "Aluno cadastrado na turma!" });
-
+      return res.status(200).json({ msg: 'Aluno cadastrado na turma!' });
     } catch (err) {
       return res.status(500).json({ error: err.message });
     }
@@ -191,11 +190,10 @@ class AdmController extends UserController {
 
       const child = await Child.findByPk(child_id);
       child.update({
-        fk_idClass: null
-      }) 
+        fk_idClass: null,
+      });
 
-      return res.status(200).json({ msg: "Aluno removido da turma!" });
-
+      return res.status(200).json({ msg: 'Aluno removido da turma!' });
     } catch (err) {
       return res.status(500).json({ error: err.message });
     }

--- a/src/app/controllers/AdmController.js
+++ b/src/app/controllers/AdmController.js
@@ -2,6 +2,7 @@ import Sequelize from 'sequelize';
 import Child from '../models/Child';
 import Professionals from '../models/Professionals';
 import User from '../models/User';
+import GuardianChild from '../models/GuardianChild';
 import UserController from './UserController';
 import dbConfig from '../../config/database';
 
@@ -35,14 +36,82 @@ class AdmController extends UserController {
   }
 
   async registerChild(req, res) {
+    const t = await sequelize.transaction();
     try {
-      const { name, registration, birthday } = req.body;
-      await Child.create({ name, registration, birthday });
+      const {
+        name, birthday, cpf1, cpf2,
+      } = req.body;
+      const child = await Child.create({ name, birthday }, { transaction: t });
+      // cpfs.forEach()
+      if (cpf1 !== undefined) {
+        const user = await User.findOne({
+          where: {
+            cpf: cpf1,
+          },
+        });
+        if (user !== null) {
+          await GuardianChild.create({ guardian_cpf: cpf1, fk_idChild: child.id, fk_idGuardian: user.id }, { transaction: t });
+        } else {
+          await GuardianChild.create({ guardian_cpf: cpf1, fk_idChild: child.id, fk_idGuardian: null }, { transaction: t });
+        }
+      }
+      if (cpf2 !== undefined) {
+        const user = await User.findOne({
+          where: {
+            cpf: cpf2,
+          },
+        });
+        if (user !== null) {
+          await GuardianChild.create({ guardian_cpf: cpf2, fk_idChild: child.id, fk_idGuardian: user.id }, { transaction: t });
+        } else {
+          await GuardianChild.create({ guardian_cpf: cpf2, fk_idChild: child.id, fk_idGuardian: null }, { transaction: t });
+        }
+      }
+      await t.commit();
+      return res.status(201).json({ message: 'Aluno cadastrado!', child });
     } catch (err) {
-      return res.status(500).json({ error: err.message });
+      t.rollback();
+      return res.status(500).json({ error: err.message, stack: err.stack });
     }
+  }
 
-    return res.status(201).json({ message: 'Aluno cadastrado!' });
+  async registerGuardianChild(req, res) {
+    const t = await sequelize.transaction();
+    try {
+      const { id, cpf } = req.body;
+
+      const child = await Child.findByPk(id);
+      if (child === null) {
+        return res.status(404).json({ message: 'Criança não foi encontrada.' });
+      }
+
+      const guardian_child_validate = await GuardianChild.findOne({
+        where: {
+          guardian_cpf: cpf,
+          fk_idChild: id,
+        },
+      });
+      if (guardian_child_validate !== null) {
+        return res.status(201).json({ message: 'Responsável já está cadastrado.' });
+      }
+
+      const user = await User.findOne({
+        where: {
+          cpf,
+        },
+      });
+      if (user !== null) {
+        await GuardianChild.create({ guardian_cpf: cpf, fk_idChild: id, fk_idGuardian: user.id }, { transaction: t });
+      } else {
+        await GuardianChild.create({ guardian_cpf: cpf, fk_idChild: id, fk_idGuardian: null }, { transaction: t });
+      }
+
+      await t.commit();
+      return res.status(201).json({ message: 'Responsável cadastrado!' });
+    } catch (err) {
+      t.rollback();
+      return res.status(500).json({ error: err.message, stack: err.stack });
+    }
   }
 
   async registerClass(req, res) {

--- a/src/app/controllers/ChildController.js
+++ b/src/app/controllers/ChildController.js
@@ -1,11 +1,22 @@
 /* eslint-disable class-methods-use-this */
 import Child from '../models/Child';
+import GuardianChild from '../models/GuardianChild';
 
 class ChildController {
   async listChilds(req, res) {
     try {
       const childList = await Child.findAll();
       return res.json(childList);
+    } catch (err) {
+      return res.status(500).json({ error: err.stack });
+    }
+  }
+
+  async listChildrenRelations(req, res) {
+    try {
+      const children = await Child.findAll();
+      const guardian_child = await GuardianChild.findAll();
+      return res.json({ children, relations: guardian_child });
     } catch (err) {
       return res.status(500).json({ error: err.stack });
     }

--- a/src/app/controllers/EventController.js
+++ b/src/app/controllers/EventController.js
@@ -1,9 +1,10 @@
 import ProjectInterface from '../others/ProjectInterface';
+
 class EventController extends ProjectInterface {
-    constructor(){
-        super();
-        this._ProjectType = 'event';
-      }
+  constructor() {
+    super();
+    this._ProjectType = 'event';
+  }
 }
 
 export default new EventController();

--- a/src/app/controllers/GuardianController.js
+++ b/src/app/controllers/GuardianController.js
@@ -39,11 +39,11 @@ class GuardianController extends UserController {
         },
       });
       await t.commit();
-      for(const element of guardian_children){
+      for (const element of guardian_children) {
         await element.update({
           fk_idGuardian: id,
         });
-      };
+      }
       return res.json({
         usertype,
         name,
@@ -70,34 +70,34 @@ class GuardianController extends UserController {
     }
   }
 
-  async listChildActivities(req, res){
+  async listChildActivities(req, res) {
     try {
       const { id } = req.query;
       const child_val = await GuardianChild.findOne({
         where: {
-          fk_idChild: id, 
-          fk_idGuardian: req.userId
-        }
+          fk_idChild: id,
+          fk_idGuardian: req.userId,
+        },
       });
-      if (child_val === null){
-        return res.status(403).json({ msg: "Essa criança não é sua ou não existe." });
+      if (child_val === null) {
+        return res.status(403).json({ msg: 'Essa criança não é sua ou não existe.' });
       }
 
       const { fk_idClass } = await Child.findByPk(id);
 
       const activities_rel = await ClassProject.findAll({
         where: {
-          fk_idClass
-        }
+          fk_idClass,
+        },
       });
 
-      var activities_list = [];
-      for(const activity_rel of activities_rel){
+      const activities_list = [];
+      for (const activity_rel of activities_rel) {
         const activity = await Project.findByPk(activity_rel.dataValues.fk_idProject);
-        activities_list.push(activity.dataValues)
+        activities_list.push(activity.dataValues);
       }
 
-      return res.json({activities_list});
+      return res.json({ activities_list });
     } catch (err) {
       return res.status(500).json({ error: err.stack });
     }

--- a/src/app/controllers/GuardianController.js
+++ b/src/app/controllers/GuardianController.js
@@ -4,6 +4,7 @@ import User from '../models/User';
 import Guardian from '../models/Guardian';
 import dbConfig from '../../config/database';
 import Project from '../models/Project';
+import GuardianChild from '../models/GuardianChild';
 
 const sequelize = new Sequelize(dbConfig.database, dbConfig.username,
   dbConfig.password, { host: dbConfig.host, dialect: dbConfig.dialect });
@@ -30,7 +31,17 @@ class GuardianController extends UserController {
         usertype, name, cpf, birthday, email, password,
       }, { transaction: t });
       await Guardian.create({ id, adress }, { transaction: t });
+      const guardian_children = await GuardianChild.findAll({
+        where: {
+          guardian_cpf: cpf,
+        },
+      });
       await t.commit();
+      guardian_children.forEach(async (element) => {
+        await element.update({
+          fk_idGuardian: id,
+        });
+      });
       return res.json({
         usertype,
         name,

--- a/src/app/models/Child.js
+++ b/src/app/models/Child.js
@@ -16,6 +16,7 @@ class Child extends Model {
     this.belongToMany(models.Guardian, { through: 'Guardian_Child' });
   } */
   static associate(models) {
+    this.belongsTo(models.Class, { foreignKey: 'fk_idClass', as: 'Class' });
     this.belongsToMany(models.GuardianChild, { as: 'Guardian', through: 'guardian_children', foreignKey: 'fk_idChild' });
   }
 }

--- a/src/app/models/Child.js
+++ b/src/app/models/Child.js
@@ -15,6 +15,9 @@ class Child extends Model {
     this.belongTo(models.Class);
     this.belongToMany(models.Guardian, { through: 'Guardian_Child' });
   } */
+  static associate(models) {
+    this.belongsToMany(models.GuardianChild, { as: 'Guardian', through: 'guardian_children', foreignKey: 'fk_idChild' });
+  }
 }
 
 export default Child;

--- a/src/app/models/Class.js
+++ b/src/app/models/Class.js
@@ -11,11 +11,11 @@ class Class extends Model {
   }
 
   static associate(models) {
-    // this.belongsTo(models.Ec, { ForeingKey: 'fk_idEc' });
-    // this.hasMany(models.Child);
+    // this.belongsTo(models.Ec, { ForeingKey: 'fk_idEc', as: 'Ec' });
     // this.hasMany(models.Activity, { through: 'class_project' });
     // this.hasMany(models.Event, { through: 'class_project' });
     // this.hasMany(models.Teacher, { through: 'class_professional' });
+    this.hasMany(models.Child, { foreignKey: 'fk_idClass', as: 'Children' });
     this.belongsToMany(models.Project, { as: 'Project', through: 'ClassProject', foreignKey: 'fk_idClass' });
   }
 }

--- a/src/app/models/ClassProject.js
+++ b/src/app/models/ClassProject.js
@@ -1,0 +1,14 @@
+import { Model, Sequelize } from 'sequelize';
+
+class ClassProject extends Model {
+  static init(sequelize) {
+    super.init({
+      fk_idClass: Sequelize.INTEGER,
+      fk_idProject: Sequelize.INTEGER,
+    }, {
+      sequelize,
+    });
+  }
+}
+
+export default ClassProject;

--- a/src/app/models/Ec.js
+++ b/src/app/models/Ec.js
@@ -11,11 +11,12 @@ class Ec extends Model {
     });
   }
 
-/*  associate(models) {
-    this.hasMany(models.Class);
-    this.hasMany(models.Adm);
-    this.hasMany(models.Teacher);
-  } */
+  // static associate(models) {
+  //   this.hasMany(models.Class, { foreignKey: 'fk_idEc', as: 'Classes' });
+  //   // this.hasMany(models.Class);
+  //   // this.hasMany(models.Adm);
+  //   // this.hasMany(models.Teacher);
+  // }
 }
 
 export default Ec;

--- a/src/app/models/Guardian.js
+++ b/src/app/models/Guardian.js
@@ -13,6 +13,10 @@ class Guardian extends Model {
     );
     return this;
   }
+
+  static associate(models) {
+    this.belongsToMany(models.GuardianChild, { as: 'Child', through: 'guardian_children', foreignKey: 'fk_idGuardian' });
+  }
 }
 
 // Guardian.hasOne(User);

--- a/src/app/models/GuardianChild.js
+++ b/src/app/models/GuardianChild.js
@@ -1,0 +1,15 @@
+import { Model, Sequelize } from 'sequelize';
+
+class GuardianChild extends Model {
+  static init(sequelize) {
+    super.init({
+      guardian_cpf: Sequelize.STRING,
+      fk_idGuardian: Sequelize.INTEGER,
+      fk_idChild: Sequelize.INTEGER,
+    }, {
+      sequelize,
+    });
+  }
+}
+
+export default GuardianChild;

--- a/src/app/others/ProjectInterface.js
+++ b/src/app/others/ProjectInterface.js
@@ -34,8 +34,6 @@ class ProjectInterface {
           if (req.userId === undefined) {
             return res.status(401).json({ error: 'Acesso negado.' });
           }
-
-          console.log(this._ProjectType);
     
           const project = await Project.create({
             fk_idProfessional: req.userId, project_type: this._ProjectType, title, description, date,

--- a/src/app/others/ProjectInterface.js
+++ b/src/app/others/ProjectInterface.js
@@ -1,3 +1,4 @@
+import ClassProject from '../models/ClassProject';
 import Project from '../models/Project';
 
 class ProjectInterface {
@@ -29,7 +30,7 @@ class ProjectInterface {
     
       async create(req, res) {
         try {
-          const { title, description, date } = req.body;
+          const { title, description, date, class_id } = req.body;
     
           if (req.userId === undefined) {
             return res.status(401).json({ error: 'Acesso negado.' });
@@ -38,6 +39,10 @@ class ProjectInterface {
           const project = await Project.create({
             fk_idProfessional: req.userId, project_type: this._ProjectType, title, description, date,
           });
+          
+          await ClassProject.create({
+            fk_idClass: class_id, fk_idProject: project.id
+          })
     
           return res.status(201).json({
             project,

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -7,9 +7,10 @@ import Ec from '../app/models/Ec';
 import Class from '../app/models/Class';
 import Child from '../app/models/Child';
 import Project from '../app/models/Project';
+import GuardianChild from '../app/models/GuardianChild';
 
-const models = [User, Ec, Class, Child, Professionals, Guardian, Project];
-const assoc = [Class, Professionals, Project];
+const models = [User, Ec, Class, Child, Professionals, Guardian, Project, GuardianChild];
+const assoc = [Class, Professionals, Project, Child, Guardian];
 
 class Database {
   constructor() {

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -8,8 +8,9 @@ import Class from '../app/models/Class';
 import Child from '../app/models/Child';
 import Project from '../app/models/Project';
 import GuardianChild from '../app/models/GuardianChild';
+import ClassProject from '../app/models/ClassProject';
 
-const models = [User, Ec, Class, Child, Professionals, Guardian, Project, GuardianChild];
+const models = [User, Ec, Class, Child, Professionals, Guardian, Project, GuardianChild, ClassProject];
 const assoc = [Class, Professionals, Project, Child, Guardian];
 
 class Database {

--- a/src/database/migrations/20210907064612-create-class.js
+++ b/src/database/migrations/20210907064612-create-class.js
@@ -6,9 +6,9 @@ module.exports = {
       type: Sequelize.INTEGER,
       autoIncrement: true,
     },
-    fk_idEc: {
+    fk_id_ec: {
       type: Sequelize.INTEGER,
-      allowNull: false,
+      // allowNull: false,
       references: { model: 'ecs', key: 'id' },
       onUpdate: 'CASCADE',
       onDelete: 'CASCADE',

--- a/src/database/migrations/20210907065243-create-child.js
+++ b/src/database/migrations/20210907065243-create-child.js
@@ -6,7 +6,7 @@ module.exports = {
       type: Sequelize.INTEGER,
       autoIncrement: true,
     },
-    fk_idClass: {
+    fk_id_class: {
       type: Sequelize.INTEGER,
       references: { model: 'classes', key: 'id' },
       onUpdate: 'CASCADE',

--- a/src/database/migrations/20210907065243-create-child.js
+++ b/src/database/migrations/20210907065243-create-child.js
@@ -20,6 +20,7 @@ module.exports = {
       type: Sequelize.INTEGER,
       allowNull: false,
       unique: true,
+      autoIncrement: true,
     },
     created_at: {
       type: Sequelize.DATE,

--- a/src/database/migrations/20210907075047-create-guardian_child.js
+++ b/src/database/migrations/20210907075047-create-guardian_child.js
@@ -1,22 +1,27 @@
 module.exports = {
-  up: (queryInterface, Sequelize) => queryInterface.createTable('guardian_child', {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('guardian_children', {
     id: {
       allowNull: false,
       primaryKey: true,
       type: Sequelize.INTEGER,
       autoIncrement: true,
     },
-    fk_idGuardian: {
+    fk_id_guardian: {
       type: Sequelize.INTEGER,
       references: { model: 'guardians', key: 'id' },
       onUpdate: 'CASCADE',
       onDelete: 'CASCADE',
+      allowNull: true,
     },
-    fk_idChild: {
+    fk_id_child: {
       type: Sequelize.INTEGER,
       references: { model: 'children', key: 'id' },
       onUpdate: 'CASCADE',
       onDelete: 'CASCADE',
+    },
+    guardian_cpf: {
+      type: Sequelize.STRING,
+      allowNull: false,
     },
     created_at: {
       type: Sequelize.DATE,

--- a/src/database/migrations/20210907075704-create-class_project.js
+++ b/src/database/migrations/20210907075704-create-class_project.js
@@ -1,18 +1,18 @@
 module.exports = {
-  up: (queryInterface, Sequelize) => queryInterface.createTable('class_project', {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('class_projects', {
     id: {
       allowNull: false,
       primaryKey: true,
       type: Sequelize.INTEGER,
       autoIncrement: true,
     },
-    fk_idClass: {
+    fk_id_class: {
       type: Sequelize.INTEGER,
       references: { model: 'classes', key: 'id' },
       onUpdate: 'CASCADE',
       onDelete: 'CASCADE',
     },
-    fk_idProject: {
+    fk_id_project: {
       type: Sequelize.INTEGER,
       references: { model: 'projects', key: 'id' },
       onUpdate: 'CASCADE',

--- a/src/routes.js
+++ b/src/routes.js
@@ -42,6 +42,6 @@ routes.get('/teacher/list-activities', (req, res) => ProjectController.listByUse
 // Guardian routes
 routes.use('/guardian', Middleware.verifyGuardian);
 routes.get('/guardian/get-activity', GuardianController.getActivityDetails);
-routes.get('/guardian/get-child-activities', GuardianController.listChildActivities)
+routes.get('/guardian/get-child-activities', GuardianController.listChildActivities);
 
 export default routes;

--- a/src/routes.js
+++ b/src/routes.js
@@ -16,14 +16,16 @@ routes.post('/register-guardian', GuardianController.register);
 // Admin routes
 routes.use('/adm', Middleware.verifyAdm);
 routes.post('/adm/register-child', AdmController.registerChild);
+routes.post('/adm/register-guardian-child', AdmController.registerGuardianChild);
 routes.post('/adm/register-teacher', TeacherController.register);
 routes.post('/adm/create-project', (req, res, next) => ProjectController.changeState(req, res, next), (req, res) => ProjectController.create(req, res));
 routes.put('/adm/update-project', (req, res, next) => ProjectController.changeState(req, res, next), (req, res) => ProjectController.update(req, res));
 routes.delete('/adm/delete-project/:type/:id', (req, res, next) => ProjectController.changeState(req, res, next), (req, res) => ProjectController.delete(req, res));
 routes.get('/adm/list-childs', ChildController.listChilds);
+routes.get('/adm/list-childs-rel', ChildController.listChildrenRelations);
 routes.get('/adm/list-professionals', TeacherController.list);
 routes.get('/adm/list-guardians', GuardianController.list);
-//routes.get('/adm/list-activities', ActivityController.list);
+// routes.get('/adm/list-activities', ActivityController.list);
 
 // Teacher routes
 routes.use('/teacher', Middleware.verifyTeacher);

--- a/src/routes.js
+++ b/src/routes.js
@@ -16,7 +16,11 @@ routes.post('/register-guardian', GuardianController.register);
 // Admin routes
 routes.use('/adm', Middleware.verifyAdm);
 routes.post('/adm/register-child', AdmController.registerChild);
+routes.post('/adm/register-class', AdmController.registerClass);
+routes.post('/adm/register-child-class', AdmController.registerChildClass);
+routes.post('/adm/remove-child-class', AdmController.removeChildClass);
 routes.post('/adm/register-guardian-child', AdmController.registerGuardianChild);
+routes.post('/adm/delete-guardian-child', AdmController.deleteGuardianChild);
 routes.post('/adm/register-teacher', TeacherController.register);
 routes.post('/adm/create-project', (req, res, next) => ProjectController.changeState(req, res, next), (req, res) => ProjectController.create(req, res));
 routes.put('/adm/update-project', (req, res, next) => ProjectController.changeState(req, res, next), (req, res) => ProjectController.update(req, res));
@@ -25,6 +29,7 @@ routes.get('/adm/list-childs', ChildController.listChilds);
 routes.get('/adm/list-childs-rel', ChildController.listChildrenRelations);
 routes.get('/adm/list-professionals', TeacherController.list);
 routes.get('/adm/list-guardians', GuardianController.list);
+routes.get('/adm/list-classes', AdmController.listClasses);
 // routes.get('/adm/list-activities', ActivityController.list);
 
 // Teacher routes
@@ -37,5 +42,6 @@ routes.get('/teacher/list-activities', (req, res) => ProjectController.listByUse
 // Guardian routes
 routes.use('/guardian', Middleware.verifyGuardian);
 routes.get('/guardian/get-activity', GuardianController.getActivityDetails);
+routes.get('/guardian/get-child-activities', GuardianController.listChildActivities)
 
 export default routes;


### PR DESCRIPTION
## O que testar:

- Criar uma child antes e depois um guardian com o cpf da criança e o inverso também, criando o guardian antes e testar se a relação foi criada.
- Agora só é possível criar uma atividade se ouver uma classe relacionada à mesma.
- Busca de atividades de uma criança específica.
- Adicionar novo responsável da criança, com guardian cadastrado e sem cadastrar.

### Novas rotas:
POST `/adm/register-class`
```JSON
{
    "code": "eoqmaluco3", 
    "capacity": 20
}
```

POST `/adm/register-child-class`
```JSON
{
    "class_id": 3,
    "child_id": 1
}
```

POST `/adm/remove-child-class`
```JSON
{
    "child_id": 1
}
```

POST `/adm/register-guardian-child`
```JSON
{
    "id": 1,
    "cpf": "dsnoss"
}
```

POST `/adm/delete-guardian-child`
```JSON
{
    "id": 1,
    "cpf": "noss"
}
```

GET `/adm/list-childs-rel`

GET `/adm/list-classes`

GET `/guardian/get-child-activities?id=1`

### Rotas Alteradas:

POST `/adm/register-child`
```JSON
{
    "name": "Teste",
    "birthday": "2007-09-12",
    "cpf1": "daospk",
    "cpf2": "noss"
}
```

POST `/teacher/create-activity`
```JSON
{
    "title": "eoq maluco, uma atividade", 
    "description": "atividade maluca", 
    "date": 31122021,
    "projectType": "activity",
    "action": "create",
    "class_id": 3
}
```

## Issue
Close #14 